### PR TITLE
Remove unused code

### DIFF
--- a/src/third_party/ptz_glitch/public/script.js
+++ b/src/third_party/ptz_glitch/public/script.js
@@ -90,8 +90,6 @@ window.addEventListener("DOMContentLoaded",
                         { video: { pan: true, tilt: true, zoom: true } }));
 
 getUserMediaVideoButton.onclick = (_) => getUserMedia({ video: true });
-getUserMediaVideoPanUnconstrainedAudioButton.onclick = (_) =>
-  getUserMedia({ audio: true, video: { tilt: true } });
 
 async function getUserMedia(constraints) {
   const sanitizedConstraints = { ...constraints };

--- a/src/third_party/ptz_glitch/public/script.js
+++ b/src/third_party/ptz_glitch/public/script.js
@@ -313,40 +313,6 @@ function updateButtons() {
   }
 }
 
-/* permissions request/revoke */
-
-requestCameraPtzTrueButton.onclick = (_) =>
-  request({ name: "camera", panTiltZoom: true });
-
-async function request(permissionDescriptor) {
-  const prefix = `navigator.permissions.request(${JSON.stringify(
-    permissionDescriptor
-  )}`;
-  try {
-    await navigator.permissions.request(permissionDescriptor);
-    log(`${prefix} -> success`);
-  } catch (error) {
-    log(`⚠️ ${prefix} -> ${error.message}`);
-  }
-  populateCameras();
-}
-
-revokeCameraPtzTrueButton.onclick = (_) =>
-  revoke({ name: "camera", panTiltZoom: true });
-
-async function revoke(permissionDescriptor) {
-  const prefix = `navigator.permissions.revoke(${JSON.stringify(
-    permissionDescriptor
-  )}`;
-  try {
-    await navigator.permissions.revoke(permissionDescriptor);
-    log(`${prefix} -> success`);
-  } catch (error) {
-    log(`⚠️ ${prefix} -> ${error.message}`);
-  }
-  populateCameras();
-}
-
 /* picture-in-picture */
 
 video.onclick = async (event) => {

--- a/src/third_party/ptz_glitch/public/script.js
+++ b/src/third_party/ptz_glitch/public/script.js
@@ -90,8 +90,6 @@ window.addEventListener("DOMContentLoaded",
                         { video: { pan: true, tilt: true, zoom: true } }));
 
 getUserMediaVideoButton.onclick = (_) => getUserMedia({ video: true });
-getUserMediaVideoPanUnconstrainedBasicButton.onclick = (_) =>
-  getUserMedia({ video: { pan: true } });
 getUserMediaVideoPtzButton.onclick = (_) =>
   getUserMedia({ video: { zoom: 400 } });
 getUserMediaVideoPanUnconstrainedAudioButton.onclick = (_) =>

--- a/src/third_party/ptz_glitch/public/script.js
+++ b/src/third_party/ptz_glitch/public/script.js
@@ -345,34 +345,6 @@ function updateMediaSession() {
   );
 }
 
-/* feature policy */
-
-if ("featurePolicy" in document) {
-  cameraFeaturePolicy.checked = document.featurePolicy.allowsFeature("camera");
-  microphoneFeaturePolicy.checked =
-    document.featurePolicy.allowsFeature("microphone");
-
-  cameraFeaturePolicy.onchange = (e) => toggleFeaturePolicy(e, "camera");
-  microphoneFeaturePolicy.onchange = (e) =>
-    toggleFeaturePolicy(e, "microphone");
-
-  function toggleFeaturePolicy(event, featurePolicyName) {
-    const params = new URLSearchParams(location.search);
-    if (event.target.checked) {
-      params.delete(featurePolicyName);
-    } else {
-      params.set(featurePolicyName, "none");
-    }
-    if (params.toString()) {
-      location.href = `${location.pathname}?${params}`;
-    } else {
-      location.href = location.pathname;
-    }
-  }
-} else {
-  cameraFeaturePolicy.disabled = true;
-  microphoneFeaturePolicy.disabled = true;
-}
 
 /* utils */
 

--- a/src/third_party/ptz_glitch/public/script.js
+++ b/src/third_party/ptz_glitch/public/script.js
@@ -90,8 +90,6 @@ window.addEventListener("DOMContentLoaded",
                         { video: { pan: true, tilt: true, zoom: true } }));
 
 getUserMediaVideoButton.onclick = (_) => getUserMedia({ video: true });
-getUserMediaVideoPtzButton.onclick = (_) =>
-  getUserMedia({ video: { zoom: 400 } });
 getUserMediaVideoPanUnconstrainedAudioButton.onclick = (_) =>
   getUserMedia({ audio: true, video: { tilt: true } });
 

--- a/src/third_party/ptz_glitch/public/script.js
+++ b/src/third_party/ptz_glitch/public/script.js
@@ -89,8 +89,6 @@ window.addEventListener("DOMContentLoaded",
                         getUserMedia( 
                         { video: { pan: true, tilt: true, zoom: true } }));
 
-getUserMediaVideoButton.onclick = (_) => getUserMedia({ video: true });
-
 async function getUserMedia(constraints) {
   const sanitizedConstraints = { ...constraints };
   if (deviceId != "default" && deviceId != "") {

--- a/src/third_party/ptz_glitch/public/script.js
+++ b/src/third_party/ptz_glitch/public/script.js
@@ -41,14 +41,6 @@ cameraSelect.onchange = (_) => {
 
 };
 
-if (
-  navigator.userAgent.includes("Chrome") &&
-  "mediaDevices" in navigator &&
-  !`"pan" in navigator.mediaDevices.getSupportedConstraints()` &&
-  !("tilt" in navigator.mediaDevices.getSupportedConstraints())
-) {
-  flagWarning.style.display = "block";
-}
 
 log(navigator.userAgent);
 
@@ -186,7 +178,8 @@ function updateButtons() {
                                     "zoom",
                                     "brightness",
                                     "contrast",
-                                    "saturation"];
+                                    "saturation",
+                                    "sharpness"];
   
 
   controllableCapabilities.forEach((name) => {
@@ -262,6 +255,13 @@ function updateButtons() {
         saturationRange.max = capabilities.saturation.max;
         saturationRange.step = capabilities.saturation.step;
         saturationRange.value = settings.saturation;
+      } else if (name == "sharpness") {
+        sharpnessIncreaseButton.dataset.step = capabilities.sharpness.step;
+        sharpnessDecreaseButton.dataset.step = -capabilities.sharpness.step;
+        sharpnessRange.min = capabilities.sharpness.min;
+        sharpnessRange.max = capabilities.sharpness.max;
+        sharpnessRange.step = capabilities.sharpness.step;
+        sharpnessRange.value = settings.sharpness;
       }
     }
   });

--- a/src/third_party/ptz_glitch/views/index.html
+++ b/src/third_party/ptz_glitch/views/index.html
@@ -111,12 +111,6 @@
 
     <p>Call <b>navigator.mediaDevices.getUserMedia</b> with</p>
     <button
-      id="getUserMediaVideoPtzButton"
-      title="Request ideally a PTZ camera and set ideal zoom"
-    >
-      video: { zoom: 400 }
-    </button>
-    <button
       id="getUserMediaVideoPanUnconstrainedAudioButton"
       title="Request audio and ideally a PTZ camera"
     >

--- a/src/third_party/ptz_glitch/views/index.html
+++ b/src/third_party/ptz_glitch/views/index.html
@@ -109,14 +109,6 @@
     <p>Pick a camera or use the default one</p>
     <select id="cameraSelect" disabled> </select>
 
-    <p>Manage the <b>panTiltZoom</b> camera permission with</p>
-    <button id="requestCameraPtzTrueButton">
-      permissions.request
-    </button>
-    <button id="revokeCameraPtzTrueButton">
-      permissions.revoke
-    </button>
-
     <p>
       Feature policy is
       <input type="checkbox" id="cameraFeaturePolicy" />

--- a/src/third_party/ptz_glitch/views/index.html
+++ b/src/third_party/ptz_glitch/views/index.html
@@ -7,10 +7,6 @@
     <script src="../public/script.js" defer></script>
   </head>
   <body>
-    <p id="flagWarning" style="display: none">
-      Turn on <b>Experimental Web Platform features</b>
-    </p>
-
     <div id="preview">
       <video id="video" autoplay muted width="380" height="140"></video>
       <div class="buttons">

--- a/src/third_party/ptz_glitch/views/index.html
+++ b/src/third_party/ptz_glitch/views/index.html
@@ -110,12 +110,6 @@
     <select id="cameraSelect" disabled> </select>
 
     <p>Call <b>navigator.mediaDevices.getUserMedia</b> with</p>
-    <button
-      id="getUserMediaVideoPanUnconstrainedAudioButton"
-      title="Request audio and ideally a PTZ camera"
-    >
-      audio: true, video: { tilt: true }
-    </button>
     <button id="getUserMediaVideoButton" title="Request any camera">
       video: true
     </button>

--- a/src/third_party/ptz_glitch/views/index.html
+++ b/src/third_party/ptz_glitch/views/index.html
@@ -109,14 +109,6 @@
     <p>Pick a camera or use the default one</p>
     <select id="cameraSelect" disabled> </select>
 
-    <p>
-      Feature policy is
-      <input type="checkbox" id="cameraFeaturePolicy" />
-      <label for="cameraFeaturePolicy">camera</label>
-      <input type="checkbox" id="microphoneFeaturePolicy" />
-      <label for="microphoneFeaturePolicy">microphone</label>
-    </p>
-
     <div id="logs"></div>
 
   </body>

--- a/src/third_party/ptz_glitch/views/index.html
+++ b/src/third_party/ptz_glitch/views/index.html
@@ -109,11 +109,6 @@
     <p>Pick a camera or use the default one</p>
     <select id="cameraSelect" disabled> </select>
 
-    <p>Call <b>navigator.mediaDevices.getUserMedia</b> with</p>
-    <button id="getUserMediaVideoButton" title="Request any camera">
-      video: true
-    </button>
-
     <p>Manage the <b>panTiltZoom</b> camera permission with</p>
     <button id="requestCameraPtzTrueButton">
       permissions.request

--- a/src/third_party/ptz_glitch/views/index.html
+++ b/src/third_party/ptz_glitch/views/index.html
@@ -111,13 +111,6 @@
 
     <p>Call <b>navigator.mediaDevices.getUserMedia</b> with</p>
     <button
-      id="getUserMediaVideoPanUnconstrainedBasicButton"
-      autofocus
-      title="Request ideally a PTZ camera"
-    >
-      video: { pan: true }
-    </button>
-    <button
       id="getUserMediaVideoPtzButton"
       title="Request ideally a PTZ camera and set ideal zoom"
     >


### PR DESCRIPTION
Because the glitch page was a glitch page and this is an extension, there's a bunch of code that isn't needed and can be removed including:
- Feature policy;
- In-extension UI controls for as the options page is the better place for them;
- Different ways of prompting that don't make sense for an extension