### PR TITLE
add a first run experience that goes to a prompt flow

### DIFF
--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -1,0 +1,8 @@
+chrome.runtime.onInstalled.addListener(({ reason }) => {
+    if (reason === chrome.runtime.OnInstalledReason.INSTALL) {
+      chrome.tabs.create({
+        url: '/extension/options.html'
+      });
+    }
+  });
+  

--- a/src/extension/options.html
+++ b/src/extension/options.html
@@ -1,6 +1,20 @@
-For PTZ Extension to control your camera, you have to click the button below
-and then click "Allow" on the prompt presented by Chrome.<br>
-If you do not do so, the extension WILL NOT work.
-<button id="requestPtzPermission">Click here to let Chrome prompt for Camera
-permissions.</button>
-<script src="options.js"></script>
+<html>
+    <head>
+        <meta charset="utf-8">
+        </head>
+    <title>Welcome to PTZ Extension 🌱!</title><p>
+    <center><h1>Welcome to PTZ Extension 🌱!</h1></center>
+    <br>
+    <h1>What is PTZ Extension</h1><p>
+    PTZ Extension is a Chrome Extension that lets you control the pan, tilt,
+    zoom, brightness, sharpness, contrast, and saturation of your webcam.
+    <h1>How do I get started?</h1><p>
+    To use PTZ Extension to control your camera you<p>
+    <span style="color: red"><strong>MUST click the button below</strong></span><br>
+    and then<br>
+    <span style="color: red"><strong>click "Allow" on the subsequent Chrome prompt.</strong></span><br><br>
+    <button id="requestPtzPermission">Click for permission prompt</button><br><br>
+    PTZ Extension uses the camera permissions to: 1) display self-view and
+    2) send the settings you select to the camera.
+    <script src="options.js"></script>
+</html>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "PTZ Extension",
     "description": "Control your webcam settings from Chrome!",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "manifest_version": 3,
     "options_page": "extension/options.html",
     "action": {
@@ -12,5 +12,8 @@
         "32": "icons/icon-32.png",
         "48": "icons/icon-48.png",
         "128": "icons/icon-128.png"
+    },
+    "background": {
+        "service_worker": "extension/background.js"
     }
 }


### PR DESCRIPTION
Currently users have to manually go to the Options page and trigger the prompt.

This change adds a default first run experience that directs users to the options page to trigger the prompt.

It also makes the option page a bit more parsable.